### PR TITLE
Fix TemplateResponse parameters in main.py

### DIFF
--- a/apache-modsec/apache-config/modsecurity.conf
+++ b/apache-modsec/apache-config/modsecurity.conf
@@ -76,6 +76,26 @@ SecRule REQUEST_METHOD "!^(GET|POST|HEAD|OPTIONS)$" \
     msg:'Non-standard HTTP method used',\
     tag:'WAF/Blocked'"
 
+# ---- 7. DoS Protection - Block IP exceeding 35 requests in 60 seconds ----
+# Rule A: Block if counter already at threshold
+SecRule IP:DOS_COUNTER "@ge 35" \
+    "id:100010,\
+    phase:1,\
+    deny,\
+    status:429,\
+    msg:'DoS Attack Detected - IP exceeded 35 requests in 60 seconds',\
+    tag:'WAF/DoS',\
+    logdata:'Blocking %{REMOTE_ADDR} - request count: %{ip.dos_counter}'"
+
+# Rule B: Increment per-IP request counter (resets after 60 seconds of inactivity)
+SecRule REQUEST_URI "@rx .*" \
+    "id:100011,\
+    phase:1,\
+    pass,\
+    nolog,\
+    setvar:ip.dos_counter=+1,\
+    expirevar:ip.dos_counter=60"
+
 # =============================================
 # OWASP CORE RULE SET (CRS) INCLUDES
 # =============================================

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -108,8 +108,7 @@ async def logs_page(
     }
     title = title_map.get(log_type, "Unknown Log Type")
 
-    return templates.TemplateResponse("logs.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "logs.html", {
         "entries": paginated,
         "page": page,
         "has_next": page < total_pages,
@@ -450,7 +449,7 @@ async def update_rule_action(rule_id: str, req: UpdateActionRequest):
 
 @app.get("/rules", response_class=HTMLResponse)
 async def rules_page(request: Request):
-    return templates.TemplateResponse("rules_management.html", {"request": request})
+    return templates.TemplateResponse(request, "rules_management.html")
 
 # === Rule Management Logic ===
 

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -49,7 +49,7 @@ async def dashboard(request: Request):
     
     total_requests = len(LOG_ENTRIES)
     blocked_requests = len([entry for entry in LOG_ENTRIES if entry.status in (406, 414)])
-    attack_attempts = len([entry for entry in LOG_ENTRIES if entry.status == 403])
+    attack_attempts = len([entry for entry in LOG_ENTRIES if entry.status in (403, 429)])
     normal_traffic = total_requests - blocked_requests - attack_attempts
 
     recent_logs = sorted(LOG_ENTRIES, key=lambda x: x.timestamp, reverse=True)[:50]
@@ -185,7 +185,7 @@ async def export_pdf(
     entries = filter_logs(log_type, rule_filter, severity_filter)
     total_requests = len(LOG_ENTRIES)
     blocked_requests = len([e for e in LOG_ENTRIES if e.status in (406, 414)])
-    attack_attempts = len([e for e in LOG_ENTRIES if e.status == 403])
+    attack_attempts = len([e for e in LOG_ENTRIES if e.status in (403, 429)])
 
     title_map = {
         "total": "Total Requests",
@@ -209,7 +209,7 @@ async def export_pdf(
         metrics_data = {
             "normal_traffic": len([e for e in entries if 200 <= e.status <= 399 or e.status in (401, 404)]),
             "blocked_requests": len([e for e in entries if e.status in (406, 414)]),
-            "attack_attempts": len([e for e in entries if e.status == 403])
+            "attack_attempts": len([e for e in entries if e.status in (403, 429)])
         }
         generate_donut_chart_image(metrics_data, donut_chart_path)
 
@@ -283,7 +283,7 @@ def filter_logs(log_type: str, rule_filter: Optional[str], severity_filter: Opti
     elif log_type == "blocked":
         entries = [e for e in entries if e.status in (406, 414)]
     elif log_type == "attack":
-        entries = [e for e in entries if e.status == 403]
+        entries = [e for e in entries if e.status in (403, 429)]
     elif log_type != "total":
         raise HTTPException(status_code=400, detail="Invalid log type")
 
@@ -380,7 +380,7 @@ def generate_donut_chart_image(metrics_data, output_path):
     plt.close()
 
 def get_matplotlib_color(status_code):
-    if status_code == 403:
+    if status_code in (403, 429):
         return '#dc3545'
     if status_code in (406, 414):
         return '#ffc107'
@@ -807,7 +807,7 @@ async def save_custom_rule(rule_data: dict):
         print("[INFO] Applied internal config changes")
 
         # Gracefully reload Apache to apply changes
-        result = subprocess.run(["apachectl", "graceful"], capture_output=True, text=True)
+        result = subprocess.run(["apache2ctl", "graceful"], capture_output=True, text=True)
         if result.returncode != 0:
             print(f"[ERROR] Apache reload failed: {result.stderr.strip()}")
             raise Exception(f"Apache reload failed: {result.stderr.strip()}")

--- a/dashboard/main.py
+++ b/dashboard/main.py
@@ -71,8 +71,7 @@ async def dashboard(request: Request):
         ip_counts[entry.ip_address] = ip_counts.get(entry.ip_address, 0) + 1
     top_ips_data = [{"ip": ip, "count": count} for ip, count in sorted(ip_counts.items(), key=lambda x: x[1], reverse=True)[:10]]
 
-    return templates.TemplateResponse("dashboard.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "dashboard.html", {
         "normal_traffic": normal_traffic,
         "blocked_requests": blocked_requests,
         "attack_attempts": attack_attempts,


### PR DESCRIPTION
In newer Starlette versions, TemplateResponse expects request as the first argument (not inside the context dict), so name ends up receiving the context dict — an unhashable type and breaking code.
Fixed in this.
<img width="1439" height="904" alt="image" src="https://github.com/user-attachments/assets/9b175806-83da-400e-9d7e-b2bb714539c2" />
